### PR TITLE
feat: add remove action for detached/conflict skills

### DIFF
--- a/src/lib/__tests__/remove-skill.test.ts
+++ b/src/lib/__tests__/remove-skill.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test'
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, symlinkSync, existsSync, lstatSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { removeFilesForSkill } from '@/lib/symlinks'
+import { removeSkill } from '@/lib/project-actions'
+
+describe('removeFilesForSkill', () => {
+  let tempDir: string
+  let projectDir: string
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'skillbook-remove-test-'))
+    projectDir = join(tempDir, 'project')
+    mkdirSync(projectDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  const createDetachedSkill = (name: string, content: string) => {
+    const skillDir = join(projectDir, '.opencode', 'skill', name)
+    mkdirSync(skillDir, { recursive: true })
+    writeFileSync(join(skillDir, 'SKILL.md'), content)
+    return skillDir
+  }
+
+  const createDetachedCursorSkill = (name: string, content: string) => {
+    const rulesDir = join(projectDir, '.cursor', 'rules')
+    mkdirSync(rulesDir, { recursive: true })
+    const skillPath = join(rulesDir, `${name}.md`)
+    writeFileSync(skillPath, content)
+    return skillPath
+  }
+
+  const createSymlinkedSkill = (name: string) => {
+    const skillbookDir = join(projectDir, '.skillbook', 'skills', name)
+    mkdirSync(skillbookDir, { recursive: true })
+    writeFileSync(join(skillbookDir, 'SKILL.md'), '# Test')
+
+    const harnessDir = join(projectDir, '.opencode', 'skill')
+    mkdirSync(harnessDir, { recursive: true })
+    symlinkSync(join('..', '..', '.skillbook', 'skills', name), join(harnessDir, name))
+    return join(harnessDir, name)
+  }
+
+  test('removes detached skill directory (opencode harness)', () => {
+    const skillDir = createDetachedSkill('test-skill', '# Test')
+    expect(existsSync(skillDir)).toBe(true)
+
+    const result = removeFilesForSkill(projectDir, ['opencode'], 'test-skill')
+
+    expect(result.success).toBe(true)
+    expect(existsSync(skillDir)).toBe(false)
+  })
+
+  test('removes detached skill file (cursor harness)', () => {
+    const skillPath = createDetachedCursorSkill('test-skill', '# Test')
+    expect(existsSync(skillPath)).toBe(true)
+
+    const result = removeFilesForSkill(projectDir, ['cursor'], 'test-skill')
+
+    expect(result.success).toBe(true)
+    expect(existsSync(skillPath)).toBe(false)
+  })
+
+  test('removes from multiple harnesses', () => {
+    const opencodeDir = createDetachedSkill('test-skill', '# Test')
+    const cursorPath = createDetachedCursorSkill('test-skill', '# Test')
+
+    expect(existsSync(opencodeDir)).toBe(true)
+    expect(existsSync(cursorPath)).toBe(true)
+
+    const result = removeFilesForSkill(projectDir, ['opencode', 'cursor'], 'test-skill')
+
+    expect(result.success).toBe(true)
+    expect(existsSync(opencodeDir)).toBe(false)
+    expect(existsSync(cursorPath)).toBe(false)
+  })
+
+  test('fails when path is a symlink', () => {
+    const symlinkPath = createSymlinkedSkill('test-skill')
+    expect(lstatSync(symlinkPath).isSymbolicLink()).toBe(true)
+
+    const result = removeFilesForSkill(projectDir, ['opencode'], 'test-skill')
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('symlink')
+    expect(existsSync(symlinkPath)).toBe(true)
+  })
+
+  test('succeeds when skill does not exist', () => {
+    const result = removeFilesForSkill(projectDir, ['opencode'], 'nonexistent')
+
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('removeSkill', () => {
+  let tempDir: string
+  let projectDir: string
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'skillbook-remove-skill-test-'))
+    projectDir = join(tempDir, 'project')
+    mkdirSync(projectDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  const createDetachedSkill = (name: string, content: string) => {
+    const harnessDir = join(projectDir, '.opencode', 'skill', name)
+    mkdirSync(harnessDir, { recursive: true })
+    writeFileSync(join(harnessDir, 'SKILL.md'), content)
+    return harnessDir
+  }
+
+  test('removes harness files when skillbook is not initialized', async () => {
+    const harnessDir = createDetachedSkill('test-skill', '# Test')
+    expect(existsSync(harnessDir)).toBe(true)
+
+    const result = await removeSkill(projectDir, 'test-skill')
+
+    expect(result.success).toBe(true)
+    expect(existsSync(harnessDir)).toBe(false)
+  })
+
+  test('removes from multiple harnesses', async () => {
+    const opencodeDir = join(projectDir, '.opencode', 'skill', 'test-skill')
+    mkdirSync(opencodeDir, { recursive: true })
+    writeFileSync(join(opencodeDir, 'SKILL.md'), '# Test')
+
+    const cursorPath = join(projectDir, '.cursor', 'rules', 'test-skill.md')
+    mkdirSync(join(projectDir, '.cursor', 'rules'), { recursive: true })
+    writeFileSync(cursorPath, '# Test')
+
+    expect(existsSync(opencodeDir)).toBe(true)
+    expect(existsSync(cursorPath)).toBe(true)
+
+    const result = await removeSkill(projectDir, 'test-skill')
+
+    expect(result.success).toBe(true)
+    expect(existsSync(opencodeDir)).toBe(false)
+    expect(existsSync(cursorPath)).toBe(false)
+  })
+})

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -13,6 +13,7 @@ import {
 import {
   createSymlinksForSkill,
   removeSymlinksForSkill,
+  removeFilesForSkill,
   convertToSymlink,
 } from '@/lib/symlinks'
 
@@ -93,6 +94,26 @@ export const uninstallSkill = async (
 ): Promise<SkillActionResult> => {
   const allHarnesses = detectHarnesses(projectPath)
   removeSymlinksForSkill(projectPath, allHarnesses, skillName)
+
+  if (isSkillbookInitialized(projectPath)) {
+    const removeResult = await removeFromSparseCheckout(projectPath, skillName)
+    if (!removeResult.success) {
+      return { success: false, error: `Failed to remove from sparse checkout: ${removeResult.error}` }
+    }
+  }
+
+  return { success: true }
+}
+
+export const removeSkill = async (
+  projectPath: string,
+  skillName: string,
+): Promise<SkillActionResult> => {
+  const allHarnesses = detectHarnesses(projectPath)
+  const filesResult = removeFilesForSkill(projectPath, allHarnesses, skillName)
+  if (!filesResult.success) {
+    return { success: false, error: filesResult.error }
+  }
 
   if (isSkillbookInitialized(projectPath)) {
     const removeResult = await removeFromSparseCheckout(projectPath, skillName)

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -3,6 +3,7 @@ import { render, Box, Text } from 'ink'
 import {
   installSkill,
   uninstallSkill,
+  removeSkill,
   pushSkillToLibrary,
   syncSkillFromLibrary,
   type SkillActionResult,
@@ -132,6 +133,9 @@ const App = ({ projectPath, inProject }: AppProps) => {
       case 'u':
         handleUninstall()
         break
+      case 'r':
+        handleRemove()
+        break
       case 'p':
         handlePush()
         break
@@ -183,6 +187,13 @@ const App = ({ projectPath, inProject }: AppProps) => {
   const handleUninstall = () => {
     if (selectedRow?.type !== 'installed-skill') return
     void runAction(uninstallSkill(projectPath, selectedRow.skill.name), () => loadData())
+  }
+
+  const handleRemove = () => {
+    if (selectedRow?.type !== 'installed-skill') return
+    const { status } = selectedRow.skill
+    if (status !== 'detached' && status !== 'conflict') return
+    void runAction(removeSkill(projectPath, selectedRow.skill.name), () => loadData())
   }
 
   const handlePush = () => {

--- a/src/tui/components/HelpBar.tsx
+++ b/src/tui/components/HelpBar.tsx
@@ -15,8 +15,8 @@ const SKILL_STATUS_ACTIONS: Record<SkillSyncStatus, string[]> = {
   ok: ['[u]ninstall'],
   ahead: ['[p]ush', '[u]ninstall'],
   behind: ['[s]ync', '[u]ninstall'],
-  detached: ['[s]ync', '[u]ninstall'],
-  conflict: ['[s]ync (use library)', '[p]ush (use local)', '[u]ninstall'],
+  detached: ['[s]ync', '[r]emove'],
+  conflict: ['[s]ync (use library)', '[p]ush (use local)', '[r]emove'],
 }
 
 const HARNESS_STATE_ACTIONS: Record<HarnessState, string[]> = {


### PR DESCRIPTION
Separates 'uninstall' (for symlinked skills) from 'remove' (for detached/conflict):
- [u]ninstall: removes symlinks and .skillbook entry (for ok/ahead/behind)
- [r]emove: deletes actual files and .skillbook entry (for detached/conflict)

This fixes the issue where detached skills could not be removed because uninstall only handles symlinks.

Closes: skill-book-4aa